### PR TITLE
Add httpx to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ pytest
 pydantic-settings
 jinja2
 python-multipart
+httpx


### PR DESCRIPTION
## Summary
- update requirements.txt with `httpx` dependency

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_684adecc1cbc8322b4f779a055c91976