### PR TITLE
Fix nested try indentation in build endpoint

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -135,35 +135,34 @@ async def build_from_prompt(
         # Save contract to file
         with open("../../meta/api-contracts.json", "w") as f:
             json.dump(contract, f, indent=2)
-        
-        # Find where you return the PromptResponse in build_from_prompt
-    try:
-        # Return response with generated code info
-        return PromptResponse(
-            id=prompt_request.id,
-            title=prompt_request.title,
-            status="success",
-            contract=contract,
-            files_generated=code_result["files_generated"],
-            message="Backend code generated successfully",
-            timestamp=datetime.now().isoformat()
-        )
-    except TypeError as e:
-        # Log serialization error
-        logger.error(f"Error serializing generated code: {str(e)}")
-    
-        # Create a serializable version of the response
-        serializable_contract = json.loads(json.dumps(contract, default=str))
-    
-        return PromptResponse(
-            id=prompt_request.id,
-            title=prompt_request.title,
-            status="success",
-            contract=serializable_contract,
-            files_generated=code_result["files_generated"],
-            message="Backend code generated successfully",
-            timestamp=datetime.now().isoformat()
-        )
+
+        try:
+            # Return response with generated code info
+            return PromptResponse(
+                id=prompt_request.id,
+                title=prompt_request.title,
+                status="success",
+                contract=contract,
+                files_generated=code_result["files_generated"],
+                message="Backend code generated successfully",
+                timestamp=datetime.now().isoformat()
+            )
+        except TypeError as e:
+            # Log serialization error
+            logger.error(f"Error serializing generated code: {str(e)}")
+
+            # Create a serializable version of the response
+            serializable_contract = json.loads(json.dumps(contract, default=str))
+
+            return PromptResponse(
+                id=prompt_request.id,
+                title=prompt_request.title,
+                status="success",
+                contract=serializable_contract,
+                files_generated=code_result["files_generated"],
+                message="Backend code generated successfully",
+                timestamp=datetime.now().isoformat()
+            )
 
         
     except Exception as e:


### PR DESCRIPTION
## Summary
- fix nested try block indentation in `build_from_prompt`
- remove stray debugging comment

## Testing
- `python -m py_compile app/main.py`

------
https://chatgpt.com/codex/tasks/task_e_684ae678d870832284fe1780019f282b