### PR TITLE
Update voice endpoint signature

### DIFF
--- a/RENDER_DEPLOYMENT.md
+++ b/RENDER_DEPLOYMENT.md
@@ -52,7 +52,7 @@ This guide provides instructions for deploying the AI Debugger Factory to Render
    - `/api/v1/health` - Should return status "healthy"
    - `/api/v1/debug/status` - Should return repository status
    - `/api/v1/build` - For generating code from prompts
-   - `/api/v1/voice` - For processing voice input
+   - `/api/v1/voice` - For processing voice input via `multipart/form-data` with an `audio_file` field and optional `options` field
    - `/api/v1/debug/contract-drift` - For checking contract drift
 
 ## Configuration

--- a/app/main.py
+++ b/app/main.py
@@ -1,4 +1,4 @@
-from fastapi import FastAPI, Depends, HTTPException, status, UploadFile, Form, Request
+from fastapi import FastAPI, Depends, HTTPException, status, UploadFile, Form, File, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
@@ -193,24 +193,18 @@ async def build_from_prompt(
         )
 
 @app.post("/api/v1/voice")
-async def process_voice(audio_file: UploadFile = None, options: Optional[str] = Form(None)):
+async def process_voice(audio_file: UploadFile = File(...), options: Optional[str] = Form(None)):
     """
     Process voice input
     
     Args:
-        audio_file: Audio file with prompt
+        audio_file: Audio file with prompt (sent as form field `audio_file`)
         options: JSON string with options
         
     Returns:
         Dictionary containing processing results
     """
     try:
-        if not audio_file:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail="Audio file is required"
-            )
-            
         # Save audio file temporarily
         temp_file_path = f"/tmp/{audio_file.filename}"
         with open(temp_file_path, "wb") as temp_file:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -196,3 +196,28 @@ def test_contract_generator():
     
     # Verify schemas
     assert isinstance(contract["schemas"], dict)
+
+
+@patch("app.main.VoiceInputProcessor")
+def test_process_voice_success(mock_voice_proc):
+    """Test voice endpoint with multipart form"""
+    mock_instance = MagicMock()
+    mock_instance.process_voice_input.return_value = {
+        "status": "success",
+        "transcribed_text": "hello world",
+        "structured_prompt": {"title": "Test", "intent": "build"},
+    }
+    mock_voice_proc.return_value = mock_instance
+
+    files = {"audio_file": ("test.wav", b"data", "audio/wav")}
+    response = client.post("/api/v1/voice", files=files)
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "success"
+    assert response.json()["transcribed_text"] == "hello world"
+
+
+def test_process_voice_missing_file():
+    """Audio file is required"""
+    response = client.post("/api/v1/voice")
+    assert response.status_code == 422


### PR DESCRIPTION
## Summary
- accept `audio_file` as `File(...)` in `/api/v1/voice`
- mention multipart usage in deployment guide
- add tests covering voice endpoint

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_684aed40ad00832292fbb3dcf2bb3c4c