### PR TITLE
Fix options handling in code generator

### DIFF
--- a/app/utils/code_generator.py
+++ b/app/utils/code_generator.py
@@ -1,6 +1,8 @@
 import logging
 import os
-from typing import Dict, List, Any, Optional
+from typing import Dict, Any, Union
+
+from app.models.prompt import PromptOptions
 
 # Set up logger
 logger = logging.getLogger(__name__)
@@ -18,7 +20,7 @@ def setup_logger():
     )
     return logging.getLogger(__name__)
 
-def generate_backend_code(prompt: str, contract: Dict[str, Any], options: Dict[str, Any]) -> Dict[str, Any]:
+def generate_backend_code(prompt: str, contract: Dict[str, Any], options: Union[Dict[str, Any], PromptOptions]) -> Dict[str, Any]:
     """
     Generate backend code based on a prompt and API contract
     
@@ -39,9 +41,13 @@ def generate_backend_code(prompt: str, contract: Dict[str, Any], options: Dict[s
     endpoints = contract.get("endpoints", [])
     schemas = contract.get("schemas", {})
     
+    # Normalize options to a dictionary
+    if hasattr(options, "dict"):
+        options = options.dict()
+
     # Determine file structure based on options
     modular_structure = options.get("modular_structure", False)
-    use_database = getattr(prompt_data.options, 'use_database', True)
+    use_database = options.get("use_database", True)
     generate_tests = options.get("generate_tests", True)
     
     # Generate files

--- a/tests/test_code_generator.py
+++ b/tests/test_code_generator.py
@@ -1,0 +1,29 @@
+import pytest
+from app.utils.code_generator import generate_backend_code
+from app.models.prompt import PromptOptions
+
+
+@pytest.fixture
+def simple_contract():
+    return {
+        "endpoints": [
+            {"path": "/api/items", "method": "GET"}
+        ],
+        "schemas": {"Item": {"type": "object", "properties": {"id": {"type": "integer"}}}}
+    }
+
+
+def test_generate_backend_code_with_dict(simple_contract):
+    options = {"use_database": False, "modular_structure": False, "generate_tests": True}
+    result = generate_backend_code("prompt", simple_contract, options)
+    assert "database/db.py" not in result["files_generated"]
+    assert result["structure_type"] == "monolithic"
+    assert result["tests_generated"] is True
+
+
+def test_generate_backend_code_with_promptoptions(simple_contract):
+    options = PromptOptions(use_database=True, modular_structure=True, generate_tests=False)
+    result = generate_backend_code("prompt", simple_contract, options)
+    assert "database/db.py" in result["files_generated"]
+    assert result["structure_type"] == "modular"
+    assert result["tests_generated"] is False

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -110,10 +110,11 @@ def test_build_from_prompt_success(mock_get_db, mock_generate_backend_code, mock
     
     # Verify mocks were called
     mock_generate_api_contract.assert_called_once_with(sample_prompt_request["prompt"])
+    expected_options = PromptOptions(**sample_prompt_request["options"])
     mock_generate_backend_code.assert_called_once_with(
         sample_prompt_request["prompt"],
         mock_contract,
-        sample_prompt_request["options"]
+        expected_options
     )
     
     # Clean up


### PR DESCRIPTION
## Summary
- fix `generate_backend_code` to rely on passed options
- support `PromptOptions` instances or dictionaries
- update server call and unit tests for new API
- add dedicated tests for `generate_backend_code`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app' / 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_684af14d306883228b27c01972b79b09