### PR TITLE
Fix GitHub uploader

### DIFF
--- a/app/utils/github_uploader.py
+++ b/app/utils/github_uploader.py
@@ -14,11 +14,15 @@ def upload_to_github(repo_name, github_token, file_paths, commit_message="Initia
         content_b64 = base64.b64encode(content).decode('utf-8')
 
         github_api_url = f"https://api.github.com/repos/{repo_name}/contents/{file_path}"
-        response = requests.put(github_api_url, headers=headers, json={
-            "message": commit_message,
-            "branch": branch,
-            "content": content_b64.decode("utf-8")
-        })
+        response = requests.put(
+            github_api_url,
+            headers=headers,
+            json={
+                "message": commit_message,
+                "branch": branch,
+                "content": content_b64,
+            },
+        )
 
         if response.status_code not in [200, 201]:
             raise Exception(f"GitHub upload failed for {file_path}: {response.text}")


### PR DESCRIPTION
## Summary
- fix GitHub uploader to send Base64 content correctly

## Testing
- `pytest -q` *(fails: ModuleNotFoundError - fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_684bd06a26348322a85111c8c38ca3b3